### PR TITLE
Use @dynamicMemberLookup instead of conforming Optional to a public protocol

### DIFF
--- a/Sources/ResilientDecoding/Resilient.swift
+++ b/Sources/ResilientDecoding/Resilient.swift
@@ -39,6 +39,7 @@ public struct Resilient<Value: Decodable>: Decodable {
     projectedValue = ProjectedValue(value: value, topLevelError: topLevelError, errorsAtOffset: errorsAtOffset)
   }
 
+  @dynamicMemberLookup
   public struct ProjectedValue {
     let value: Value
 


### PR DESCRIPTION
This removes the underscored property and conformance from Optional while maintaining the same API. There is still an underscored public type in DEBUG, but now it is namespaced to `Resilient.ProjectedValue`.