### PR TITLE
Fix typo on Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ enum MyEnum: String, ResilientRawRepresentable {
 ### Property-Level Errors
 
 In `DEBUG` builds, `Resilient` properties provide a `projectedValue` with information about errors encountered during decoding. Scalar types, such as `Optional` and `ResilientRawRepresentable`, provide a single `error` property. Developers can determine if an error ocurred during decoding by accessing `$foo.error` for a property written `@Resilient var foo: Int?`.
-`@Resilient` `Array` properties provide two error fields: `errors` and `results`. `errors` is the list of all errors that were recovered from when decoding the array. `results` interleaves these errors with elements of the array that were successfully decoded. For instance, the `results` for a property written `@Resilient var baz: [Int]` when decodinf the JSON snippet `[1, 2, "3"]` would be two `.success` values followed by a `.failure`.
+`@Resilient` `Array` properties provide two error fields: `errors` and `results`. `errors` is the list of all errors that were recovered from when decoding the array. `results` interleaves these errors with elements of the array that were successfully decoded. For instance, the `results` for a property written `@Resilient var baz: [Int]` when decoding the JSON snippet `[1, 2, "3"]` would be two `.success` values followed by a `.failure`.
 
 ### `ResilientDecodingErrorReporter`
 


### PR DESCRIPTION
Just a typo `decodinf` -> `decoding`