### PR TITLE
Build the project in release on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,8 @@ jobs:
     - uses: actions/checkout@v2
     - name: Select Xcode version
       run: sudo xcode-select -switch /Applications/Xcode_11.4.app
-    - name: Build project
-      run: swift build
+    - name: Build project (Release)
+      run: swift build -c Release
     - name: Run tests
       run: swift test
     - name: Validate Podspec

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     - name: Select Xcode version
       run: sudo xcode-select -switch /Applications/Xcode_11.4.app
     - name: Build project (Release)
-      run: swift build -c Release
+      run: swift build -c release
     - name: Run tests
       run: swift test
     - name: Validate Podspec


### PR DESCRIPTION
Since we have some Debug/Release branching I think we need to validate both builds. `swift test` will still build the package in debug.