### PR TITLE
Version 1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ After running this code, `foo` will be a `Foo` where `foo.array == [1, 3]` and `
 In your Package.swift:
 ```swift
   dependencies: [
-    .package(name: "ResilientDecoding", url: "https://github.com/airbnb/ResilientDecoding.git", from: "0.9.0"),
+    .package(name: "ResilientDecoding", url: "https://github.com/airbnb/ResilientDecoding.git", from: "1.0.0"),
   ]
 ```
 
@@ -43,7 +43,7 @@ In your `Podfile`:
 
 ```
 platform :ios, '12.0'
-pod 'ResilientDecoding', '~> 0.9'
+pod 'ResilientDecoding', '~> 1.0'
 ```
 
 ## Decoding

--- a/ResilientDecoding.podspec
+++ b/ResilientDecoding.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'ResilientDecoding'
-  s.version  = '0.9.1'
+  s.version  = '1.0.0'
   s.license  = 'MIT'
   s.summary  = 'A cache that enables the performant persistence of individual messages to disk'
   s.homepage = 'https://github.com/airbnb/ResilientDecoding'


### PR DESCRIPTION
I think we are in a good spot now to release `1.0`. The one breaking change is `ErrorDigest` being returned from `ResilientDecodingErrorReporter` instead of `[Error]`. 

Once this is merge, I will tag the resulting commit with `1.0.0`.