### PR TITLE
Move Podspec validation to separate CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,6 @@ jobs:
       run: swift test -c debug
     - name: Test in Release
       run: swift test -c release
-    - name: Validate Podspec
-      run: bundle install && bundle exec pod lib lint --verbose --fail-fast
 
   build-linux:
     runs-on: ubuntu-latest
@@ -27,3 +25,10 @@ jobs:
     - uses: Didstopia/SwiftAction@v1.0.2
       with:
         swift-action: 'test'
+
+  validate-podspec:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Validate Podspec
+      run: bundle install && bundle exec pod lib lint --verbose --fail-fast


### PR DESCRIPTION
Move podspec validation to a separate CI job to make this run in parallel, since it's the longest running job right now, we can start running this before all the other jobs in `build-macos` are finished.