### PR TITLE
[iOS] Add simplified error reporting API

### DIFF
--- a/Tests/ResilientDecodingTests/ResilientDecodingErrorReporterTests.swift
+++ b/Tests/ResilientDecodingTests/ResilientDecodingErrorReporterTests.swift
@@ -20,8 +20,12 @@ final class ResilientDecodingErrorReporterTests: XCTestCase {
         "resilientEnum": "novel",
       }
       """.data(using: .utf8)!)
+    guard let errorDigest = errorReporter.flushReportedErrors() else {
+      XCTFail()
+      return
+    }
     #if DEBUG
-    XCTAssertEqual(errorReporter.flushReportedErrors()?.debugDescription, """
+    XCTAssertEqual(errorDigest.debugDescription, """
       resilientArray
         Index 1
           - Could not decode as `Int`
@@ -31,6 +35,8 @@ final class ResilientDecodingErrorReporterTests: XCTestCase {
         - Unknown novel value "novel" (this error is not reported by default)
       """)
     #endif
+    // Ensure that the error digest was actually flushed
+    XCTAssertNil(errorReporter.flushReportedErrors())
   }
 
 }

--- a/Tests/ResilientDecodingTests/ResilientDecodingTests.swift
+++ b/Tests/ResilientDecodingTests/ResilientDecodingTests.swift
@@ -32,12 +32,9 @@ extension XCTestCase {
 
   func decodeMock<T: Decodable>(_ type: T.Type, _ string: String, expectedErrorCount: Int = 0) throws -> T {
     let decoder = JSONDecoder()
-    let errorReporter = decoder.enableResilientDecodingErrorReporting()
-    let decoded = try decoder.decode(T.self, from: string.data(using: .utf8)!)
-    let errorDigest = errorReporter.flushReportedErrors()
+    let data = string.data(using: .utf8)!
+    let (decoded, errorDigest) = try decoder.decode(T.self, from: data, reportResilientDecodingErrors: true)
     XCTAssertEqual(errorDigest?.errors.count ?? 0, expectedErrorCount)
-    // Ensure that errors were actually flushed
-    XCTAssertNil(errorReporter.flushReportedErrors())
     return decoded
   }
 


### PR DESCRIPTION
The API can be seen [here](
https://github.com/GeorgeLyon/ResilientDecoding/blob/7f2692dc7997fe55038087aea201a75c15ec563a/Tests/ResilientDecodingTests/ResilientDecodingTests.swift#L36):
```swift
let (decoded, errorDigest) = try decoder.decode(T.self, from: data, reportResilientDecodingErrors: true)
```

There is also a bit of cleanup in `ErrorReporter.swift`