### PR TITLE
Add missing initializer

### DIFF
--- a/Sources/ResilientDecoding/Resilient.swift
+++ b/Sources/ResilientDecoding/Resilient.swift
@@ -31,6 +31,11 @@ public struct Resilient<Value: Decodable>: Decodable {
     self.outcome = outcome
   }
 
+  public init(wrappedValue: Value) {
+    self.wrappedValue = wrappedValue
+    self.outcome = .decodedSuccessfully
+  }
+
   public let wrappedValue: Value
 
   let outcome: ResilientDecodingOutcome


### PR DESCRIPTION
On an assignment in an initialization of a wrapped value the call will be translated to `var property: Resilient<Value> = Resilient(wrappedValue: value)` (see https://docs.swift.org/swift-book/LanguageGuide/Properties.html)
This commit adds the missing initializer `init(wrappedValue: Value)`