### PR TITLE
Enable custom types to report errors via ResilientDecodingErrorReporter

### DIFF
--- a/ResilientDecoding.podspec
+++ b/ResilientDecoding.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'ResilientDecoding'
-  s.version  = '1.0.2'
+  s.version  = '1.1.0'
   s.license  = 'MIT'
   s.summary  = 'A library you can use to partially recover from decoding errors'
   s.homepage = 'https://github.com/airbnb/ResilientDecoding'

--- a/Sources/ResilientDecoding/ErrorReporting.swift
+++ b/Sources/ResilientDecoding/ErrorReporting.swift
@@ -146,10 +146,9 @@ public struct ErrorDigest {
 extension Decoder {
 
   /**
-   This method should be called whenever an error is handled by the `Resilient` infrastructure.
-   Care should be taken that this is called on the most relevant `Decoder` object, since this method uses the `Decoder`'s `codingPath` to place the error in the correct location in the tree.
+   Reports an error which did not cause decoding to fail. This error can be accessed after decoding is complete using `ResilientDecodingErrorReporter`. Care should be taken that this is called on the most relevant `Decoder` object, since this method uses the `Decoder`'s `codingPath` to place the error in the correct location in the tree.
    */
-  func resilientDecodingHandled(_ error: Swift.Error) {
+  public func reportError(_ error: Swift.Error) {
     guard let errorReporterAny = userInfo[.resilientDecodingErrorReporter] else {
       return
     }

--- a/Sources/ResilientDecoding/Resilient.swift
+++ b/Sources/ResilientDecoding/Resilient.swift
@@ -137,7 +137,7 @@ extension KeyedDecodingContainer {
         }
         return try body(decoder)
       } catch {
-        decoder.resilientDecodingHandled(error)
+        decoder.reportError(error)
         return Resilient(fallback(), outcome: .recoveredFrom(error, wasReported: true))
       }
     } catch {

--- a/Sources/ResilientDecoding/ResilientArray.swift
+++ b/Sources/ResilientDecoding/ResilientArray.swift
@@ -64,13 +64,13 @@ extension Decoder {
         do {
           results.append(.success(transform(try elementDecoder.singleValueContainer().decode(IntermediateElement.self))))
         } catch {
-          elementDecoder.resilientDecodingHandled(error)
+          elementDecoder.reportError(error)
           results.append(.failure(error))
         }
       }
       return Resilient(results)
     } catch {
-      resilientDecodingHandled(error)
+      reportError(error)
       return Resilient([], outcome: .recoveredFrom(error, wasReported: true))
     }
   }

--- a/Sources/ResilientDecoding/ResilientDictionary.swift
+++ b/Sources/ResilientDecoding/ResilientDictionary.swift
@@ -54,7 +54,7 @@ extension Decoder {
         .mapValues { $0.result.map(transform) }
       return Resilient(value)
     } catch {
-      resilientDecodingHandled(error)
+      reportError(error)
       return Resilient([:], outcome: .recoveredFrom(error, wasReported: true))
     }
   }
@@ -73,7 +73,7 @@ private struct DecodingResultContainer<Success: Decodable>: Decodable {
       do {
         return try decoder.singleValueContainer().decode(Success.self)
       } catch {
-        decoder.resilientDecodingHandled(error)
+        decoder.reportError(error)
         throw error
       }
     }

--- a/Sources/ResilientDecoding/ResilientRawRepresentable.swift
+++ b/Sources/ResilientDecoding/ResilientRawRepresentable.swift
@@ -104,7 +104,7 @@ extension KeyedDecodingContainer {
         do {
           return Resilient(try ResilientRawRepresentableContainer(from: decoder).value).map { $0 }
         } catch {
-          decoder.resilientDecodingHandled(error)
+          decoder.reportError(error)
           return Resilient(T.decodingFallback, outcome: .recoveredFrom(error, wasReported: true))
         }
       })


### PR DESCRIPTION
`Resilient` was designed to be very strict so that it wouldn't be used in surprising ways. That said, there are use cases that `Resilient` does not explicitly support that can still benefit from reporting non-failure errors. This is a low risk way to support this while we work on building out `Resilient` to support more use cases. 

For example, if we have a value that can be decoded as an `Int`, we might want to add a fallback decoding path that decodes an `Int` from a `String`. If we still want to consider having to use the fallback path an error, we can't currently achieve this with `Resilient`, but this allows us to code this logic manually and report an error if the fallback path is used.