### PR TITLE
Make Resilient equatable or hashable if its value is so

### DIFF
--- a/Sources/ResilientDecoding/Resilient+Equatable.swift
+++ b/Sources/ResilientDecoding/Resilient+Equatable.swift
@@ -1,0 +1,8 @@
+// Created by Suyeol Jeon on 7/16/20.
+// Copyright © 2020 Airbnb Inc.
+
+extension Resilient: Equatable where Value: Equatable {
+  public static func == (lhs: Resilient<Value>, rhs: Resilient<Value>) -> Bool {
+    return lhs.wrappedValue == rhs.wrappedValue
+  }
+}

--- a/Sources/ResilientDecoding/Resilient+Hashable.swift
+++ b/Sources/ResilientDecoding/Resilient+Hashable.swift
@@ -1,0 +1,8 @@
+// Created by Suyeol Jeon on 7/16/20.
+// Copyright © 2020 Airbnb Inc.
+
+extension Resilient: Hashable where Value: Hashable {
+  public func hash(into hasher: inout Hasher) {
+    hasher.combine(self.wrappedValue)
+  }
+}

--- a/Tests/ResilientDecodingTests/EquatableTests.swift
+++ b/Tests/ResilientDecodingTests/EquatableTests.swift
@@ -1,0 +1,22 @@
+// Created by Suyeol Jeon on 7/16/20.
+// Copyright © 2020 Airbnb Inc.
+
+import ResilientDecoding
+import XCTest
+
+private struct ResilientObject: Decodable, Equatable {
+  @Resilient var resilientValue: Int?
+}
+
+final class EquatableTests: XCTestCase {
+  func testEqual() {
+    XCTAssertEqual(ResilientObject(resilientValue: 10), ResilientObject(resilientValue: 10))
+  }
+
+  func testDecodedObjectEqual() throws {
+    let decoder = JSONDecoder()
+    let decodedObject1 = try decoder.decode(ResilientObject.self, from: #"{"resilientValue": "invalid"}"#.data(using: .utf8)!)
+    let decodedObject2 = try decoder.decode(ResilientObject.self, from: #"{"resilientValue": "wrong"}"#.data(using: .utf8)!)
+    XCTAssertEqual(decodedObject1, decodedObject2)
+  }
+}

--- a/Tests/ResilientDecodingTests/HashableTests.swift
+++ b/Tests/ResilientDecodingTests/HashableTests.swift
@@ -1,0 +1,22 @@
+// Created by Suyeol Jeon on 7/16/20.
+// Copyright © 2020 Airbnb Inc.
+
+import ResilientDecoding
+import XCTest
+
+private struct ResilientObject: Decodable, Hashable {
+  @Resilient var resilientValue: Int?
+}
+
+final class HashableTests: XCTestCase {
+  func testHashable() {
+    XCTAssertEqual(ResilientObject(resilientValue: 10).hashValue, ResilientObject(resilientValue: 10).hashValue)
+  }
+
+  func testDecodedObjectHashable() throws {
+    let decoder = JSONDecoder()
+    let decodedObject1 = try decoder.decode(ResilientObject.self, from: #"{"resilientValue": "invalid"}"#.data(using: .utf8)!)
+    let decodedObject2 = try decoder.decode(ResilientObject.self, from: #"{"resilientValue": "wrong"}"#.data(using: .utf8)!)
+    XCTAssertEqual(decodedObject1.hashValue, decodedObject2.hashValue)
+  }
+}


### PR DESCRIPTION
`@Resilient` doesn't respect Equatable and Hashable.

```swift
struct Foo: Decodable, Equatable {
  var bar: String // ✅ Works
}
```

```swift
struct Foo: Decodable, Equatable {
  @Resilient var bar: String // 🚫 Compile error
}
```

Make `@Resilient` equatable when the value is equatable, and same for Hashable.
