### PR TITLE
Sorts ErrorDigest by keys and returns sorted errors

### DIFF
--- a/Sources/ResilientDecoding/ErrorReporting.swift
+++ b/Sources/ResilientDecoding/ErrorReporting.swift
@@ -134,9 +134,13 @@ public struct ErrorDigest {
     }
 
     var errors: [Error] {
-      shallowErrors + children.flatMap { $0.value.errors }
+      shallowErrors
+        + children
+        .sorted { $0.key < $1.key }
+        .flatMap { $0.value.errors }
     }
   }
+
   fileprivate var root = Node()
 
 }


### PR DESCRIPTION
Sorts ErrorDigest error output so that it consistently returns the errors in the same order when decoding the same data.

In answer to https://github.com/airbnb/ResilientDecoding/issues/30

@dfed 