### PR TITLE
ResilientDecoding is not, in fact, Carthage compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 ![](https://github.com/airbnb/ResilientDecoding/workflows/Build/badge.svg) 
 [![Swift Package Manager compatible](https://img.shields.io/badge/SPM-compatible-4BC51D.svg?style=flat)](https://github.com/apple/swift-package-manager)
-[![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
 [![Version](https://img.shields.io/cocoapods/v/ResilientDecoding.svg)](https://cocoapods.org/pods/ResilientDecoding)
 [![License](https://img.shields.io/cocoapods/l/ResilientDecoding.svg)](https://cocoapods.org/pods/ResilientDecoding)
 [![Platform](https://img.shields.io/badge/platform-watchos%20%7C%20ios%20%7C%20tvos%20%7C%20macos%20%7C%20linux-lightgrey.svg?style=flat)](https://cocoapods.org/pods/ResilientDecoding)


### PR DESCRIPTION
It looks like [Carthage requires an Xcode project to be committed to the project if you want Carthage to build your project from source](https://github.com/Carthage/Carthage#share-your-xcode-schemes). Running `carthage build --no-skip-current` in this repo fails with the following error:

> *** Skipped building ResilientDecoding due to the error:
Dependency "ResilientDecoding" has no shared framework schemes

As such, I'm removing the badge from the README.