### PR TITLE
Implement Hashable & Equatable on Resilient type

### DIFF
--- a/Tests/ResilientDecodingTests/ResilientTests.swift
+++ b/Tests/ResilientDecodingTests/ResilientTests.swift
@@ -1,0 +1,44 @@
+import ResilientDecoding
+import XCTest
+
+final class ResilientTests: XCTestCase {
+  struct Wrapper: Decodable, Hashable {
+    @Resilient var value: ResilientEnumWithFallback
+  }
+
+  func testResilientEquatable() throws {
+    let json1 = """
+      {
+          "value": ""
+      }
+      """.data(using: .utf8)!
+    let json2 = """
+      {
+          "value": "nonexisting"
+      }
+      """.data(using: .utf8)!
+
+    let decoded1 = try JSONDecoder().decode(Wrapper.self, from: json1)
+    let decoded2 = try JSONDecoder().decode(Wrapper.self, from: json2)
+
+    XCTAssertEqual(decoded1, decoded2)
+  }
+
+  func testResilientHashable() throws {
+    let json1 = """
+      {
+          "value": ""
+      }
+      """.data(using: .utf8)!
+    let json2 = """
+      {
+          "value": "nonexisting"
+      }
+      """.data(using: .utf8)!
+
+    let decoded1 = try JSONDecoder().decode(Wrapper.self, from: json1)
+    let decoded2 = try JSONDecoder().decode(Wrapper.self, from: json2)
+
+    XCTAssertEqual(decoded1.hashValue, decoded2.hashValue)
+  }
+}


### PR DESCRIPTION
Add `Hashable` and `Equatable` conformance to `Resilient` where `Value` also conforms to `Equatable` and `Hashable`.