### PR TITLE
Make Resilient conditionally conform to Equatable and Hashable

### DIFF
--- a/Sources/ResilientDecoding/Resilient.swift
+++ b/Sources/ResilientDecoding/Resilient.swift
@@ -71,6 +71,22 @@ public struct Resilient<Value: Decodable>: Decodable {
   
 }
 
+// MARK: Equatable
+
+extension Resilient: Equatable where Value: Equatable {
+  public static func ==(lhs: Self, rhs: Self) -> Bool {
+    lhs.wrappedValue == rhs.wrappedValue
+  }
+}
+
+// MARK: Hashable
+
+extension Resilient: Hashable where Value: Hashable {
+  public func hash(into hasher: inout Hasher) {
+    hasher.combine(wrappedValue)
+  }
+}
+
 // MARK: - Decoding Outcome
 
 #if DEBUG


### PR DESCRIPTION
This PR makes `Resilient` conditionally conform to `Equatable` and `Hashable` when `Value` conforms to `Equatable` or `Hashable`.

This lets us simplify code like:

```swift
struct RemoteFileUpload {
  let value: String?
  let fileType: String?
  let fileName: String?
  @Resilient var url: URL?
  let content: Data?
}

/// Manual `Equatable` conformance is required when using `@Resilient`.
extension RemoteFileUpload: Equatable {
  static func ==(lhs: RemoteFileUpload, rhs: RemoteFileUpload) -> Bool {
    lhs.value == rhs.value
      && lhs.fileType == rhs.fileType
      && lhs.fileName == rhs.fileName
      && lhs.url == rhs.url
      && lhs.content == rhs.content
  }
}
```

to just:

```swift
struct RemoteFileUpload: Equatable {
  let value: String?
  let fileType: String?
  let fileName: String?
  @Resilient var url: URL?
  let content: Data?
}
```