### PR TITLE
Update CI to use macOS 14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,6 @@ jobs:
     - uses: actions/checkout@v2
     - name: Run on Xcode 15.4
       run: sudo xcode-select -switch /Applications/Xcode_15.4.app
-    - name: Generate linux tests
-      # Makes sure the linux tests were generated properly (can only be run on macOS)
-      run: swift test --generate-linuxmain && git update-index --refresh && git diff-index --quiet HEAD --
     - name: Test in Debug
       run: swift test -c debug
     - name: Test in Release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,27 +4,15 @@ on: [push, pull_request]
 
 jobs:
   build-macos:
-    runs-on: macOS-11
+    runs-on: macOS-14
     steps:
     # Checks-out the repo. More at: https://github.com/actions/checkout
     - uses: actions/checkout@v2
-    - name: Run on Xcode 11
-      run: sudo xcode-select -switch /Applications/Xcode_11.7.app
+    - name: Run on Xcode 15.4
+      run: sudo xcode-select -switch /Applications/Xcode_15.4.app
     - name: Generate linux tests
       # Makes sure the linux tests were generated properly (can only be run on macOS)
       run: swift test --generate-linuxmain && git update-index --refresh && git diff-index --quiet HEAD --
-    - name: Test in Debug
-      run: swift test -c debug
-    - name: Test in Release
-      run: swift test -c release
-  
-  build-macos-xcode-12:
-    runs-on: macOS-11
-    steps:
-    # Checks-out the repo. More at: https://github.com/actions/checkout
-    - uses: actions/checkout@v2
-    - name: Run on Xcode 12
-      run: sudo xcode-select -switch /Applications/Xcode_12.4.app
     - name: Test in Debug
       run: swift test -c debug
     - name: Test in Release
@@ -39,7 +27,7 @@ jobs:
         swift-action: 'test'
 
   validate-podspec:
-    runs-on: macOS-11
+    runs-on: macOS-14
     steps:
     - uses: actions/checkout@v2
     - name: Validate Podspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source 'https://rubygems.org'
 
-gem 'cocoapods', '~> 1.11.0'
+gem 'cocoapods', '~> 1.15.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,30 +1,39 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    CFPropertyList (3.0.5)
+    CFPropertyList (3.0.7)
+      base64
+      nkf
       rexml
-    activesupport (6.1.7.6)
-      concurrent-ruby (~> 1.0, >= 1.0.2)
+    activesupport (7.2.1)
+      base64
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.3.1)
+      connection_pool (>= 2.2.5)
+      drb
       i18n (>= 1.6, < 2)
+      logger (>= 1.4.2)
       minitest (>= 5.1)
-      tzinfo (~> 2.0)
-      zeitwerk (~> 2.3)
-    addressable (2.8.1)
-      public_suffix (>= 2.0.2, < 6.0)
+      securerandom (>= 0.3)
+      tzinfo (~> 2.0, >= 2.0.5)
+    addressable (2.8.7)
+      public_suffix (>= 2.0.2, < 7.0)
     algoliasearch (1.27.5)
       httpclient (~> 2.8, >= 2.8.3)
       json (>= 1.5.1)
     atomos (0.1.3)
+    base64 (0.2.0)
+    bigdecimal (3.1.8)
     claide (1.1.0)
-    cocoapods (1.11.3)
+    cocoapods (1.15.2)
       addressable (~> 2.8)
       claide (>= 1.0.2, < 2.0)
-      cocoapods-core (= 1.11.3)
+      cocoapods-core (= 1.15.2)
       cocoapods-deintegrate (>= 1.0.3, < 2.0)
-      cocoapods-downloader (>= 1.4.0, < 2.0)
+      cocoapods-downloader (>= 2.1, < 3.0)
       cocoapods-plugins (>= 1.0.0, < 2.0)
       cocoapods-search (>= 1.0.0, < 2.0)
-      cocoapods-trunk (>= 1.4.0, < 2.0)
+      cocoapods-trunk (>= 1.6.0, < 2.0)
       cocoapods-try (>= 1.1.0, < 2.0)
       colored2 (~> 3.1)
       escape (~> 0.0.4)
@@ -32,10 +41,10 @@ GEM
       gh_inspector (~> 1.0)
       molinillo (~> 0.8.0)
       nap (~> 1.0)
-      ruby-macho (>= 1.0, < 3.0)
-      xcodeproj (>= 1.21.0, < 2.0)
-    cocoapods-core (1.11.3)
-      activesupport (>= 5.0, < 7)
+      ruby-macho (>= 2.3.0, < 3.0)
+      xcodeproj (>= 1.23.0, < 2.0)
+    cocoapods-core (1.15.2)
+      activesupport (>= 5.0, < 8)
       addressable (~> 2.8)
       algoliasearch (~> 1.0)
       concurrent-ruby (~> 1.1)
@@ -45,7 +54,7 @@ GEM
       public_suffix (~> 4.0)
       typhoeus (~> 1.0)
     cocoapods-deintegrate (1.0.5)
-    cocoapods-downloader (1.6.3)
+    cocoapods-downloader (2.1)
     cocoapods-plugins (1.0.0)
       nap
     cocoapods-search (1.0.1)
@@ -54,46 +63,68 @@ GEM
       netrc (~> 0.11)
     cocoapods-try (1.2.0)
     colored2 (3.1.2)
-    concurrent-ruby (1.2.2)
+    concurrent-ruby (1.3.4)
+    connection_pool (2.4.1)
+    drb (2.2.1)
     escape (0.0.4)
     ethon (0.16.0)
       ffi (>= 1.15.0)
-    ffi (1.15.5)
+    ffi (1.17.0)
+    ffi (1.17.0-aarch64-linux-gnu)
+    ffi (1.17.0-aarch64-linux-musl)
+    ffi (1.17.0-arm-linux-gnu)
+    ffi (1.17.0-arm-linux-musl)
+    ffi (1.17.0-arm64-darwin)
+    ffi (1.17.0-x86-linux-gnu)
+    ffi (1.17.0-x86-linux-musl)
+    ffi (1.17.0-x86_64-darwin)
+    ffi (1.17.0-x86_64-linux-gnu)
+    ffi (1.17.0-x86_64-linux-musl)
     fourflusher (2.3.1)
     fuzzy_match (2.0.4)
     gh_inspector (1.1.3)
     httpclient (2.8.3)
-    i18n (1.14.1)
+    i18n (1.14.6)
       concurrent-ruby (~> 1.0)
-    json (2.6.3)
-    minitest (5.19.0)
+    json (2.7.2)
+    logger (1.6.1)
+    minitest (5.25.1)
     molinillo (0.8.0)
     nanaimo (0.3.0)
     nap (1.1.0)
     netrc (0.11.0)
+    nkf (0.2.0)
     public_suffix (4.0.7)
-    rexml (3.2.8)
-      strscan (>= 3.0.9)
+    rexml (3.3.7)
     ruby-macho (2.5.1)
-    strscan (3.1.0)
-    typhoeus (1.4.0)
+    securerandom (0.3.1)
+    typhoeus (1.4.1)
       ethon (>= 0.9.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    xcodeproj (1.22.0)
+    xcodeproj (1.25.0)
       CFPropertyList (>= 2.3.3, < 4.0)
       atomos (~> 0.1.3)
       claide (>= 1.0.2, < 2.0)
       colored2 (~> 3.1)
       nanaimo (~> 0.3.0)
-      rexml (~> 3.2.4)
-    zeitwerk (2.6.11)
+      rexml (>= 3.3.2, < 4.0)
 
 PLATFORMS
+  aarch64-linux-gnu
+  aarch64-linux-musl
+  arm-linux-gnu
+  arm-linux-musl
+  arm64-darwin
   ruby
+  x86-linux-gnu
+  x86-linux-musl
+  x86_64-darwin
+  x86_64-linux-gnu
+  x86_64-linux-musl
 
 DEPENDENCIES
-  cocoapods (~> 1.11.0)
+  cocoapods (~> 1.15.0)
 
 BUNDLED WITH
-   2.3.15
+   2.5.20


### PR DESCRIPTION
CI currently specifies macOS 11, which is no longer supported on GitHub actions.

This PR updates CI to use macOS 14 / Xcode 15.4.