### PR TITLE
ci: add permissions: contents: read to ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
     - main
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build-macos:
     runs-on: macOS-14


### PR DESCRIPTION
Sets the minimum-required `GITHUB_TOKEN` scope on `ci.yml`:

- Workflow-level `permissions:` -> `contents: read`
- No changes to jobs, steps, runners, or triggers
- YAML still parses (`yaml.safe_load` succeeds)

Rationale:

- The CI test job is read-only; nothing in it needs write access to the repo.
- Without an explicit block, the run inherits whatever default the repository's actions settings happen to be set to. That default has drifted in the past, and forks-of-forks lose track of it.
- the OpenSSF Scorecard Token-Permissions check flags missing per-workflow permissions as a finding.
- After the tj-actions/changed-files supply-chain incident from March 2025, the cost-benefit on explicit minimum scopes is firmly on the side of declaring them.
