### PR TITLE
ci: set explicit read permissions on build workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
     - main
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build-macos:
     runs-on: macOS-14


### PR DESCRIPTION
Adds `permissions: contents: read` to the Build CI workflow.

By default, the GITHUB_TOKEN in Actions workflows has broad read/write access. Since this workflow only checks out code and runs `swift test` / `pod lib lint`, it only requires read access to the repository contents. Explicitly declaring this follows the least-privilege principle and limits exposure if a third-party action were compromised.

See also: https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token